### PR TITLE
Eliminate dispatching from LocalDataStore + Updated the LocalDataStor…

### DIFF
--- a/Cliqz/Connect/ConnectTableViewController.swift
+++ b/Cliqz/Connect/ConnectTableViewController.swift
@@ -115,9 +115,9 @@ class ConnectTableViewController: SubSettingsTableViewController {
     @objc private func connectionSucceeded() {
         
         let successfulConnectionKey = "SuccessfulConnection"
-        if LocalDataStore.objectForKey(successfulConnectionKey) == nil {
+        if LocalDataStore.value(forKey: successfulConnectionKey) == nil {
             showFirstSuccessfulConnectionAlert()
-            LocalDataStore.setObject(true, forKey: successfulConnectionKey)
+            LocalDataStore.set(value: true, forKey: successfulConnectionKey)
         }
     }
     

--- a/Cliqz/Extensions/AppDelegateExtension.swift
+++ b/Cliqz/Extensions/AppDelegateExtension.swift
@@ -19,8 +19,7 @@ extension AppDelegate {
             // Clean install, record install date
             if UserDefaults.standard.value(forKey: InstallDateKey) == nil {
                 //Avoid overrides
-                UserDefaults.standard.set(Date().timeIntervalSince1970, forKey: InstallDateKey)
-                UserDefaults.standard.synchronize()
+                LocalDataStore.set(value: Date().timeIntervalSince1970, forKey: InstallDateKey)
             }
         }
     }

--- a/Cliqz/Extensions/UIDeviceExtension.swift
+++ b/Cliqz/Extensions/UIDeviceExtension.swift
@@ -23,7 +23,7 @@ public extension UIDevice {
     
     var modelName: String {
         let identifierKey = "UIDevice.identifier"
-        let storedIdentified = LocalDataStore.objectForKey(identifierKey) as? String
+        let storedIdentified = LocalDataStore.value(forKey: identifierKey) as? String
         guard storedIdentified == nil  else {
             return storedIdentified!
         }
@@ -75,7 +75,7 @@ public extension UIDevice {
         default:                                        deviceIdentifier = identifier
         }
         
-        LocalDataStore.setObject(deviceIdentifier, forKey: identifierKey)
+        LocalDataStore.set(value: deviceIdentifier, forKey: identifierKey)
         return deviceIdentifier
     }
 

--- a/Cliqz/MyOffrz/OffrzDataSource.swift
+++ b/Cliqz/MyOffrz/OffrzDataSource.swift
@@ -44,7 +44,7 @@ class OffrzDataSource {
 
 	func markCurrentOffrSeen() {
 		self.currentOffr?.isSeen = true
-		LocalDataStore.setObject(self.currentOffr?.uid, forKey: OffrzDataSource.LastSeenOffrID)
+        LocalDataStore.set(value: self.currentOffr?.uid, forKey: OffrzDataSource.LastSeenOffrID)
 	}
 
     func hasOffrz() -> Bool {
@@ -52,7 +52,7 @@ class OffrzDataSource {
     }
 
     func shouldShowOnBoarding() -> Bool {
-		guard let _ = LocalDataStore.objectForKey(OffrzDataSource.OffrzOnboardingKey)
+        guard let _ = LocalDataStore.value(forKey: OffrzDataSource.OffrzOnboardingKey)
 			else {
 			return true
 		}
@@ -60,7 +60,7 @@ class OffrzDataSource {
     }
 
     func hideOnBoarding() {
-		LocalDataStore.setObject("closed", forKey: OffrzDataSource.OffrzOnboardingKey)
+        LocalDataStore.set(value: "closed", forKey: OffrzDataSource.OffrzOnboardingKey)
     }
 
 	private func updateMyOffrzList() {
@@ -71,7 +71,7 @@ class OffrzDataSource {
 					self.currentOffr = o
 					self.currentOffr?.isSeen = true
 				} else {
-				LocalDataStore.removeObjectForKey(OffrzDataSource.LastSeenOffrID)
+                    LocalDataStore.removeObject(forKey: OffrzDataSource.LastSeenOffrID)
 					self.currentOffr = self.getNotExpiredOffr()
 				}
 			}
@@ -100,7 +100,7 @@ class OffrzDataSource {
     }
 
 	private func getLastSeenOffrID() -> String? {
-		return LocalDataStore.objectForKey(OffrzDataSource.LastSeenOffrID) as? String
+        return LocalDataStore.value(forKey: OffrzDataSource.LastSeenOffrID) as? String
 	}
 
 	private func isExpiredOffr(_ offr: Offr) -> Bool {

--- a/Cliqz/React Components/Modules/UserAgentConstants.swift
+++ b/Cliqz/React Components/Modules/UserAgentConstants.swift
@@ -38,19 +38,18 @@ open class UserAgentConstants : RCTEventEmitter {
         }
         else {
             let installDate: Date
-            if let installDateTime = UserDefaults.standard.value(forKey: InstallDateKey) as? Double {
+            if let installDateTime = LocalDataStore.value(forKey: InstallDateKey) as? Double {
                 installDate = Date(timeIntervalSince1970: installDateTime)
             }
             else {
                 installDate = Date()
                 //register the install date
-                UserDefaults.standard.set(installDate.timeIntervalSince1970, forKey: InstallDateKey)
-                UserDefaults.standard.synchronize()
+                LocalDataStore.set(value: installDate.timeIntervalSince1970, forKey: InstallDateKey)
             }
             return String(installDate.daysSince1970())
         }
         #endif
-        return "16917";
+        //return "16917";
     }
     
     open override static func moduleName() -> String! {

--- a/Cliqz/Search/SubscriptionsHandler.swift
+++ b/Cliqz/Search/SubscriptionsHandler.swift
@@ -238,7 +238,7 @@ class SubscriptionsHandler: NSObject {
     
     private func loadCurrentSubscriptions() -> [String: [String: [String]]] {
 
-        if let storedSubscriptions = LocalDataStore.objectForKey(subscriptionsKey) as? [String: [String: [String]]] {
+        if let storedSubscriptions = LocalDataStore.value(forKey: subscriptionsKey) as? [String: [String: [String]]] {
             return storedSubscriptions
         } else {
             return [String: [String: [String]]]()
@@ -246,7 +246,7 @@ class SubscriptionsHandler: NSObject {
     }
     
     private func saveCurrentSubscriptions() {
-        LocalDataStore.setObject(currentSubscription, forKey: subscriptionsKey)
+        LocalDataStore.set(value: currentSubscription, forKey: subscriptionsKey)
     }
     
     private func registerForUserNotifications() {

--- a/Cliqz/Services/AWSSNSManager.swift
+++ b/Cliqz/Services/AWSSNSManager.swift
@@ -47,7 +47,7 @@ class AWSSNSManager {
 	}
 	
 	class func createPlatformEndpoint(withDeviceToken deviceToken: String, completionHandler: @escaping (Bool) -> Void) {
-		if let oldToken = (LocalDataStore.objectForKey(tokenKey) as? String), oldToken == deviceToken {
+        if let oldToken = (LocalDataStore.value(forKey: tokenKey) as? String), oldToken == deviceToken {
 			return
 		}
 
@@ -57,10 +57,10 @@ class AWSSNSManager {
 		request?.platformApplicationArn = SNSAplicationArn
 		sns.createPlatformEndpoint(request!).continueWith(executor: AWSExecutor.mainThread()) { (task: AWSTask!) -> Any? in
 			if task.error != nil {
-				LocalDataStore.removeObjectForKey(tokenKey)
+                LocalDataStore.removeObject(forKey: tokenKey)
 			} else if let createEndpointResponse = task.result,
 				let endpointArn = createEndpointResponse.endpointArn {
-				LocalDataStore.setObject(deviceToken, forKey: tokenKey)
+                LocalDataStore.set(value: deviceToken, forKey: tokenKey)
 				subscriptForNotification(endpointArn, completionHandler: completionHandler)
 				return nil
 			}

--- a/Cliqz/Services/LocalDataStore.swift
+++ b/Cliqz/Services/LocalDataStore.swift
@@ -10,25 +10,18 @@ import Foundation
 
 class LocalDataStore {
     static let defaults = UserDefaults.standard
-    
-    // wrtiting operation is done on Main thread because of a bug in FireFox that it is changing UI when any change is done to user defaults
-    static let dispatchQueue = DispatchQueue.main
 
-    class func setObject(_ value: Any?, forKey: String) {
-        dispatchQueue.async {
-            defaults.set(value, forKey: forKey)
-            defaults.synchronize()
-        }
+    class func set(value: Any?, forKey: String) {
+        defaults.set(value, forKey: forKey)
+        defaults.synchronize()
     }
     
-    class func objectForKey(_ key: String) -> Any? {
-        return defaults.object(forKey: key) as Any?
+    class func value(forKey: String) -> Any? {
+        return defaults.value(forKey: forKey) as Any?
     }
     
-    class func removeObjectForKey(_ key: String) {
-        dispatchQueue.async {
-            defaults.removeObject(forKey: key)
-            defaults.synchronize()
-        }
+    class func removeObject(forKey: String) {
+        defaults.removeObject(forKey: forKey)
+        defaults.synchronize()
     }
 }

--- a/Cliqz/Services/LocationManager.swift
+++ b/Cliqz/Services/LocationManager.swift
@@ -98,10 +98,10 @@ open class LocationManager: NSObject, CLLocationManagerDelegate {
         //empty the array
         permissionCallbacks = []
         
-        let currentLocationStatus = LocalDataStore.objectForKey(locationStatusKey)
+        let currentLocationStatus = LocalDataStore.value(forKey: locationStatusKey)
         if currentLocationStatus == nil || currentLocationStatus as! String != status.stringValue() {
             //TelemetryLogger.sharedInstance.logEvent(.LocationServicesStatus("status_change", status.stringValue()))
-            LocalDataStore.setObject(status.stringValue(), forKey: locationStatusKey)
+            LocalDataStore.set(value: status.stringValue(), forKey: locationStatusKey)
         }
     }
     

--- a/Cliqz/Services/SettingsPrefs.swift
+++ b/Cliqz/Services/SettingsPrefs.swift
@@ -212,28 +212,28 @@ class SettingsPrefs {
     func getSendCrashReportsPref() -> Bool {
         // Need to get "settings.sendCrashReports" this way so that Sentry can be initialized before getting the Profile.
         let defaultValue = true
-        if let sendCrashReportsPref = LocalDataStore.objectForKey(SettingsPrefs.SendCrashReports) as? Bool {
+        if let sendCrashReportsPref = LocalDataStore.value(forKey: SettingsPrefs.SendCrashReports) as? Bool {
             return sendCrashReportsPref
         }
         return defaultValue
     }
     
     func updateSendCrashReportsPref(_ newValue: Bool) {
-        LocalDataStore.setObject(newValue, forKey: SettingsPrefs.SendCrashReports)
+        LocalDataStore.set(value: newValue, forKey: SettingsPrefs.SendCrashReports)
         
     }
     
     func getSendUsageDataPref() -> Bool {
         // Need to get "settings.sendCrashReports" this way so that Sentry can be initialized before getting the Profile.
         let defaultValue = true
-        if let sendUsageDataPref = LocalDataStore.objectForKey(SettingsPrefs.SendUsageData) as? Bool {
+        if let sendUsageDataPref = LocalDataStore.value(forKey: SettingsPrefs.SendUsageData) as? Bool {
             return sendUsageDataPref
         }
         return defaultValue
     }
     
     func updateSendUsageDataPref(_ newValue: Bool) {
-        LocalDataStore.setObject(newValue, forKey: SettingsPrefs.SendUsageData)
+        LocalDataStore.set(value: newValue, forKey: SettingsPrefs.SendUsageData)
     }
 
     // MARK: - Private helper metods


### PR DESCRIPTION
@mahmoud-cliqz I took out the dispatches. I adapted the syntax to Swift, since most of the things in Swift are values...and we don't save classes (which are objects) in UserDefaults.
