### PR TITLE
Compact db, and write in autorelease pool.

### DIFF
--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -256,7 +256,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UIViewControllerRestorati
                     // Realm will automatically detect new properties and removed properties
                     // And will update the schema on disk automatically
                 }
-        })
+            },
+            shouldCompactOnLaunch: { (totalBytes, usedBytes) in
+                return true
+            }
+        )
         
         // Tell Realm to use this new configuration object for the default Realm
         Realm.Configuration.defaultConfiguration = config


### PR DESCRIPTION
Realm requires that writes on the background thread must be done in an autorelease pool. 

On start, clean the db.
